### PR TITLE
Fixed build failures

### DIFF
--- a/components/Layout/Footer.js
+++ b/components/Layout/Footer.js
@@ -19,11 +19,9 @@ const Footer = () => {
         </Text>
 
         <Link href='/user-agreements'>
-          <Flex>
-            <Text fontSize='sm' mt={2} color={"purple"}>
-              Terms of Service & Privacy Policy
-            </Text>
-          </Flex>
+          <Text fontSize='sm' mt={2} color={"purple"} cursor='pointer'>
+            Terms of Service & Privacy Policy
+          </Text>
         </Link>
       </Flex>
     </Flex>

--- a/lib/build.js
+++ b/lib/build.js
@@ -48,19 +48,15 @@ const updateRecord = async (record) => {
     year,
   });
 
-  if (id === "rec9osNatmgJWM0JI") {
-    console.log("Start Wars record", omdbData);
-  }
-
   if (omdbData.Response === "False") {
-    console.log("Failed to match to OMDB data:", omdbData.Error);
-    let error = {
+    console.log("Failed to match to OMDB data:", omdbData.Error, id, title);
+    let errorRecord = {
       id,
       fields: {
         Error: true,
       },
     };
-    base("Movies").update(error);
+    base("Movies").update([errorRecord]);
   } else {
     let fields = {};
     let fieldUpdateCount = 0;

--- a/lib/build.js
+++ b/lib/build.js
@@ -9,25 +9,25 @@ const base = new Airtable({ apiKey: process.env.AIRTABLE_API_KEY }).base(
 );
 
 // BUILD STEPS
-const getRecords = () => {
+const getAndUpdateRecords = async () => {
   base("Movies")
     .select({
       view: "Published",
-      filterByFormula: "{Published}",
+      filterByFormula: "NOT({Error})",
       // maxRecords: 4,
     })
     .eachPage(
       function page(records, fetchNextPage) {
-        records.forEach(function (record) {
-          updateRecord(record);
+        records.forEach(async function (record) {
+          await updateRecord(record);
         });
 
         fetchNextPage();
       },
-      function done(err) {
+      function done(err, records) {
         if (err) {
           console.error(err);
-          return;
+          return records;
         }
       }
     );
@@ -48,46 +48,66 @@ const updateRecord = async (record) => {
     year,
   });
 
-  let fields = {};
-  let fieldUpdateCount = 0;
-
-  if (!imdb_id) {
-    fields.imdb_id = omdbData.imdbID;
-    fieldUpdateCount++;
+  if (id === "rec9osNatmgJWM0JI") {
+    console.log("Start Wars record", omdbData);
   }
 
-  if (!images || images.length === 0) {
-    fields.Images = [
-      {
-        url: omdbData.Poster,
+  if (omdbData.Response === "False") {
+    console.log("Failed to match to OMDB data:", omdbData.Error);
+    let error = {
+      id,
+      fields: {
+        Error: true,
       },
-    ];
-    fieldUpdateCount++;
-  }
+    };
+    base("Movies").update(error);
+  } else {
+    let fields = {};
+    let fieldUpdateCount = 0;
 
-  if (!slug) {
-    fields.Slug = [
-      slugify(record.fields.Movie),
-      slugify(record.fields.Year),
-      record.id,
-    ].join("/");
-    fieldUpdateCount++;
-  }
+    if (!imdb_id) {
+      fields.imdb_id = omdbData.imdbID;
+      fieldUpdateCount++;
+    }
 
-  if (!omdb) {
-    fields.OMDB = JSON.stringify(omdbData);
-    fieldUpdateCount++;
-  }
+    if (!images || images.length === 0) {
+      fields.Images = [
+        {
+          url: omdbData.Poster,
+        },
+      ];
+      fieldUpdateCount++;
+    }
 
-  let updatedRecord = {
-    id,
-    fields,
-  };
+    if (!slug) {
+      fields.Slug = [
+        slugify(record.fields.Movie),
+        slugify(record.fields.Year),
+        record.id,
+      ].join("/");
+      fieldUpdateCount++;
+    }
 
-  // Only update when needed
-  if (fieldUpdateCount > 0) {
-    console.log(`Updating: ${id} ${title}`);
-    base("Movies").update([updatedRecord]);
+    if (!omdb) {
+      fields.OMDB = JSON.stringify(omdbData);
+      fieldUpdateCount++;
+    }
+
+    let updatedRecord = {
+      id,
+      fields,
+    };
+
+    // Only update when needed
+    if (fieldUpdateCount > 0) {
+      try {
+        base("Movies").update([updatedRecord]);
+        console.log(`Updated: ${id} ${title}`);
+      } catch (error) {
+        console.log(`Failed to update: ${id} ${title}`);
+        return;
+      }
+    }
   }
 };
 
@@ -110,11 +130,17 @@ function slugify(string) {
     .replace(/-+$/, ""); // Trim - from end of text
 }
 
-export const updateDatabase = () => {
+export const updateDatabase = async () => {
   /**
    * 1. Page through Airtable records
    * 2. Fetch data from OMDB
    * 3. Sync missing data to Airtable record (imdb_id, stringified OMDB object, slug)
    */
-  getRecords();
+  let movies = await getAndUpdateRecords();
+  if (!movies) {
+    console.log("updateDatabase movies undefined");
+    // TODO: Currently here
+  } else {
+    console.log("updateDatabase movies defined");
+  }
 };

--- a/lib/movies.js
+++ b/lib/movies.js
@@ -9,7 +9,13 @@ const base = new Airtable({ apiKey: process.env.AIRTABLE_API_KEY }).base(
 );
 
 // PRIVATE FUNCTIONS
-
+const isMovieValid = (record) => {
+  let { id, fields } = record;
+  if (!id || !fields.Slug) {
+    return false;
+  }
+  return true;
+};
 const formatMovie = (record) => {
   return {
     id: record.id,
@@ -25,14 +31,24 @@ const getAirtableMovieRecords = async () => {
     base("Movies")
       .select({
         view: "Published",
-        filterByFormula: "{Published}",
+        filterByFormula: "NOT({Error})",
       })
       .all()
       .then((records) => {
         console.log("Fetched " + records.length + " movies");
+
         records.forEach(function (record) {
-          movieList.push(formatMovie(record));
+          if (isMovieValid(record)) {
+            movieList.push(formatMovie(record));
+          } else {
+            console.log(
+              "Movie validation failed: ",
+              record.id,
+              record.fields.Movie
+            );
+          }
         });
+
         resolve(movieList);
       })
       .catch((err) => {

--- a/pages/index.js
+++ b/pages/index.js
@@ -14,7 +14,7 @@ import { updateDatabase } from "../lib/build";
 
 // Static Prop Generation
 export async function getStaticProps() {
-  updateDatabase(); // Update Airtable records on build
+  await updateDatabase(); // Update Airtable records on build
 
   const movieList = await fetchMovieList();
   return {


### PR DESCRIPTION
Builds would fail if the movie record didn't return a match via the OMDB API

Primary changes:

- Added validation check in lib\movies.js getAirTableMovieRecords() to omit incomplete records before returning to getStaticProps 
- Fixed syntax so that Error flag is auto-set on Airtable record when a record doesn't match in OMDB